### PR TITLE
SLING-12001 Store MockFindResourcesHandler/MockQueryResourceHandler in MockResourceResolverFactoryOptions so they are available to all resource resolvers

### DIFF
--- a/src/main/java/org/apache/sling/testing/resourceresolver/MockResourceResolver.java
+++ b/src/main/java/org/apache/sling/testing/resourceresolver/MockResourceResolver.java
@@ -67,9 +67,6 @@ public class MockResourceResolver extends SlingAdaptable implements ResourceReso
 
     private Map<String,Object> propertyMap;
 
-    private final List<MockFindResourcesHandler> findResourcesHandlers = new ArrayList<>();
-    private final List<MockQueryResourceHandler> queryResourcesHandlers = new ArrayList<>();
-
     public MockResourceResolver(final MockResourceResolverFactoryOptions options,
             final MockResourceResolverFactory factory,
             final Map<String, Map<String, Object>> resources) {
@@ -480,7 +477,7 @@ public class MockResourceResolver extends SlingAdaptable implements ResourceReso
     @Override
     @SuppressWarnings("null")
     public @NotNull Iterator<Resource> findResources(final @NotNull String query, final String language) {
-        return findResourcesHandlers.stream()
+        return options.getFindResourcesHandlers().stream()
             .map(handler -> handler.findResources(query, language))
             .filter(Objects::nonNull)
             .findFirst()
@@ -501,13 +498,13 @@ public class MockResourceResolver extends SlingAdaptable implements ResourceReso
     }
 
     void addFindResourceHandlerInternal(@NotNull MockFindResourcesHandler handler) {
-        findResourcesHandlers.add(handler);
+        options.addFindResourceHandler(handler);
     }
 
     @Override
     @SuppressWarnings("null")
     public @NotNull Iterator<Map<String, Object>> queryResources(@NotNull String query, String language) {
-        return queryResourcesHandlers.stream()
+        return options.getQueryResourcesHandlers().stream()
                 .map(handler -> handler.queryResources(query, language))
                 .filter(Objects::nonNull)
                 .findFirst()
@@ -528,7 +525,7 @@ public class MockResourceResolver extends SlingAdaptable implements ResourceReso
     }
 
     void addQueryResourceHandlerInternal(@NotNull MockQueryResourceHandler handler) {
-        queryResourcesHandlers.add(handler);
+        options.addQueryResourceHandlerInternal(handler);
     }
 
     // Sling API 2.24.0

--- a/src/main/java/org/apache/sling/testing/resourceresolver/MockResourceResolverFactoryOptions.java
+++ b/src/main/java/org/apache/sling/testing/resourceresolver/MockResourceResolverFactoryOptions.java
@@ -18,6 +18,9 @@
  */
 package org.apache.sling.testing.resourceresolver;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.osgi.service.event.EventAdmin;
@@ -34,6 +37,9 @@ public class MockResourceResolverFactoryOptions {
     private String[] searchPaths = new String[] {"/apps/", "/libs/"};
 
     private boolean mangleNamespacePrefixes;
+
+    private final List<MockFindResourcesHandler> findResourcesHandlers = new ArrayList<>();
+    private final List<MockQueryResourceHandler> queryResourcesHandlers = new ArrayList<>();
 
     public @Nullable EventAdmin getEventAdmin() {
         return eventAdmin;
@@ -71,10 +77,26 @@ public class MockResourceResolverFactoryOptions {
         }
         return mockResourceFactory;
     }
-    
+
     public @NotNull MockResourceResolverFactoryOptions setMockResourceFactory(MockResourceFactory factory) {
         this.mockResourceFactory = factory;
         return this;
+    }
+
+    public void addFindResourceHandler(@NotNull MockFindResourcesHandler handler) {
+        findResourcesHandlers.add(handler);
+    }
+
+    public @NotNull List<MockFindResourcesHandler> getFindResourcesHandlers() {
+        return findResourcesHandlers;
+    }
+
+    public void addQueryResourceHandlerInternal(@NotNull MockQueryResourceHandler handler) {
+        queryResourcesHandlers.add(handler);
+    }
+
+    public @NotNull List<MockQueryResourceHandler> getQueryResourcesHandlers() {
+        return queryResourcesHandlers;
     }
 
 }

--- a/src/main/java/org/apache/sling/testing/resourceresolver/package-info.java
+++ b/src/main/java/org/apache/sling/testing/resourceresolver/package-info.java
@@ -19,5 +19,5 @@
 /**
  * Apache Sling Testing Resource Resolver Mock
  */
-@org.osgi.annotation.versioning.Version("2.3.0")
+@org.osgi.annotation.versioning.Version("2.4.0")
 package org.apache.sling.testing.resourceresolver;

--- a/src/test/java/org/apache/sling/testing/resourceresolver/FindQueryResourcesResourceResolverFactoryOptionsTest.java
+++ b/src/test/java/org/apache/sling/testing/resourceresolver/FindQueryResourcesResourceResolverFactoryOptionsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.testing.resourceresolver;
+
+import java.util.Arrays;
+
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Rule;
+
+public class FindQueryResourcesResourceResolverFactoryOptionsTest extends FindQueryResourcesTest {
+
+    @Rule
+    public SlingContext context = new SlingContext(ResourceResolverType.NONE);
+
+    @Override
+    protected ResourceResolver createResourceResolver_addFindResourceHandlers(MockFindResourcesHandler... handlers) throws LoginException {
+        // set handler on other resource resolver created in setUp
+        Arrays.stream(handlers).forEach(handler -> MockFindQueryResources.addFindResourceHandler(resourceResolver, handler));
+        return createResourceResolver();
+    }
+
+    @Override
+    protected ResourceResolver createResourceResolver_addQueryResourceHandlers(MockQueryResourceHandler... handlers) throws LoginException {
+        // set handler on other resource resolver created in setUp
+        Arrays.stream(handlers).forEach(handler -> MockFindQueryResources.addQueryResourceHandler(resourceResolver, handler));
+        return createResourceResolver();
+    }
+
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-12001

this is an alternative to https://github.com/apache/sling-org-apache-sling-testing-resourceresolver-mock/pull/10